### PR TITLE
[FIX] Transactions to itself

### DIFF
--- a/lib/numscriptex.ex
+++ b/lib/numscriptex.ex
@@ -56,7 +56,7 @@ defmodule Numscriptex do
 
   ```elixir
   iex> Numscriptex.version()
-  %{numscriptex: "v0.2.0", numscript_wasm: "v0.0.2"}
+  %{numscriptex: "v0.2.2", numscript_wasm: "v0.0.2"}
   ```
   """
   @spec version() :: %{numscriptex: binary(), numscript_wasm: binary()}

--- a/lib/numscriptex/balances.ex
+++ b/lib/numscriptex/balances.ex
@@ -129,10 +129,13 @@ defmodule Numscriptex.Balances do
 
   defp calculate_final_balance(balance, posting, initial_balance) do
     same_asset? = posting["asset"] == balance["asset"]
-    source? = posting["source"] === balance["account"]
-    destination? = posting["destination"] === balance["account"]
+    source? = posting["source"] == balance["account"]
+    destination? = posting["destination"] == balance["account"]
 
     cond do
+      source? and destination? and same_asset? ->
+        initial_balance
+
       source? and same_asset? ->
         initial_balance - posting["amount"]
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Numscriptex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/PagoPlus/numscriptex"
-  @version "0.2.0"
+  @version "0.2.2"
 
   def project do
     [

--- a/test/numscriptex_test.exs
+++ b/test/numscriptex_test.exs
@@ -739,6 +739,117 @@ defmodule NumscriptexTest do
              ]
     end
 
+    test "transactions to itself" do
+      balances = %{"user" => %{"USD/2" => 1000}}
+      struct = build_run_struct(balances, %{}, %{})
+
+      script = """
+      send [USD/2 1000] (
+        source = @user
+        destination = @user
+      )
+      """
+
+      assert {:ok, result} = Numscriptex.run(script, struct)
+
+      assert result.postings == [
+               %{
+                 amount: 1000,
+                 asset: "USD/2",
+                 destination: "user",
+                 source: "user"
+               }
+             ]
+
+      assert result.balances == [
+               %{
+                 account: "user",
+                 asset: "USD/2",
+                 final_balance: 1000,
+                 initial_balance: 1000
+               }
+             ]
+    end
+
+    test "transactions to itself and another destination" do
+      balances = %{"user" => %{"USD/2" => 1000}, "user2" => %{"USD/2" => 1000}}
+      struct = build_run_struct(balances, %{}, %{})
+
+      script = """
+      send [USD/2 1000] (
+        source = @user
+        destination = {
+          62% to @user
+          27% to @user2
+          remaining to @user3
+        }
+      )
+      """
+
+      assert {:ok, result} = Numscriptex.run(script, struct)
+
+      assert result.postings == [
+               %{
+                 amount: 620,
+                 asset: "USD/2",
+                 destination: "user",
+                 source: "user"
+               },
+               %{
+                 amount: 270,
+                 asset: "USD/2",
+                 destination: "user2",
+                 source: "user"
+               },
+               %{
+                 source: "user",
+                 destination: "user3",
+                 amount: 110,
+                 asset: "USD/2"
+               }
+             ]
+
+      assert result.balances == [
+               %{
+                 account: "user",
+                 asset: "USD/2",
+                 final_balance: 620,
+                 initial_balance: 1000
+               },
+               %{
+                 account: "user2",
+                 asset: "USD/2",
+                 final_balance: 1270,
+                 initial_balance: 1000
+               },
+               %{
+                 account: "user3",
+                 asset: "USD/2",
+                 final_balance: 110,
+                 initial_balance: 0
+               }
+             ]
+    end
+
+    test "save a minimum amount from source" do
+      balances = %{"user" => %{"USD/2" => 1000}}
+      struct = build_run_struct(balances, %{}, %{})
+
+      script = """
+      // Now that we are saving $5 from the total amount of $10,
+      // the user will only have $5 to spend, thus failing the transaction
+      // given that the user will need $5,01.
+      save [USD/2 500] from @user
+      send [USD/2 501] (
+        source = @user
+        destination = @dest
+      )
+      """
+
+      assert {:error, error} = Numscriptex.run(script, struct)
+      assert error.details == "Not enough funds. Needed [USD/2 501] (only [USD/2 500] available)"
+    end
+
     test "with insufficient amount" do
       script = """
       send [USD/2 100] (


### PR DESCRIPTION
The expected behavior when a source send money to itself was to not change the account balance, but instead the amount was being subtracted. This PR fix this behavior.

Ex:
Considering this numscript below, and that the `@user` has a total balance of $5 (5000 as a integer):
```
send [USD/2 1000] (
  source = @user
  destination = @user
)
```
With the bug the final balance of the `@user` account will be $4 (4000 as a integer), but the correct behavior would be the balance not changing at all and still be $5